### PR TITLE
LiveRe 댓글 영역 포함을 위해 댓글 스타일 division 포함관계 치환

### DIFF
--- a/views/Main/Post/Permalink/Comment.pug
+++ b/views/Main/Post/Permalink/Comment.pug
@@ -1,8 +1,8 @@
-s_rp
-  div(
-    class='px-4 lg:px-0 lg:max-w-screen-lg lg:w-pem lg:mx-auto'
-    x-data='{ shown: false }'
-    x-intersect.once='shown = true')
+div(
+  class='px-4 lg:px-0 lg:max-w-screen-lg lg:w-pem lg:mx-auto'
+  x-data='{ shown: false }'
+  x-intersect.once='shown = true')
+  s_rp
     div(x-show='shown')
       +form('rp')
       +list('rp', 'rp2', true)


### PR DESCRIPTION
# 요약
<img width="298" alt="image" src="https://user-images.githubusercontent.com/1524891/236046843-06475e4d-f4ef-44fb-91f6-2b6d7c7c6588.png">

LiveRe 를 사용하는데에 스타일이 자연스럽도록 합니다.

# 변경사항

### Before
<img width="1274" alt="image" src="https://user-images.githubusercontent.com/1524891/236046507-c4a9e1c9-bf67-4cbc-b76f-4455e810d821.png">

### After
<img width="1271" alt="image" src="https://user-images.githubusercontent.com/1524891/236046728-37ddccfa-894b-4447-8bbd-1a472d5e2b77.png">
